### PR TITLE
sync with AnacondaRecipes

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
         - pip
     run:
         - python
-        - pyreadline  # [win]
+        - pyreadline >=1.7.1  # [win]
 
 test:
     imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,10 +25,18 @@ test:
         - dill
 
 about:
-    home: http://www.cacr.caltech.edu/~mmckerns
+    home: http://www.cacr.caltech.edu/~mmckerns/dill.htm
     license: BSD 3-Clause
+    license_family: BSD
     license_file: LICENSE
-    summary: 'A utility for serialization of python objects.'
+    summary: Serialize all of python (almost)
+    description: |
+        Dill extends Python's 'pickle' module for serializing and
+        de-serializing Python objects to he majority of the built-in python
+        types.
+    doc_url: http://trac.mystic.cacr.caltech.edu/project/pathos/wiki/dill.html
+    doc_source_url: https://github.com/uqfoundation/dill/blob/master/README.md
+    dev_url: https://github.com/uqfoundation/dill
 
 extra:
     recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
     script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
-    build:
+    host:
         - python
         - pip
     run:


### PR DESCRIPTION
add minimum version to pyreadline dependency
switch from build to host as recommended when using conda build 3
update entries in about section